### PR TITLE
Fixed a bad access crash when using a glyph which is not in the glyph records

### DIFF
--- a/aggx/rfpx/data/GlyfTable.hx
+++ b/aggx/rfpx/data/GlyfTable.hx
@@ -54,6 +54,6 @@ class GlyfTable
 	//---------------------------------------------------------------------------------------------------
 	public function getGlyphRecord(idx:UInt):GlyphRecord
 	{
-		return _glyphRecords[idx];
+		return idx < _glyphRecords.length ? _glyphRecords[idx] : null;
 	}
 }


### PR DESCRIPTION
The Haxe Vector has unspecified results for out-of-bounds access, meaning that the previous code worked sometimes.
Now it should always work, as no out-of-bounds access in the upper bounds should be allowed.
